### PR TITLE
:wrench: add option to set qemu display

### DIFF
--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"context"
 
@@ -56,13 +57,24 @@ func (q *QEMU) Create(ctx context.Context) error {
 		log.Infof("ISO at %s", q.machineConfig.ISO)
 	}
 
+	display := "-nographic"
+
+	// this could be something like
+	// -vga qxl -spice port=5900,disable-ticketing,addr=127.0.0.1"
+	// see qemu docs for more info
+	if q.machineConfig.Display != "" {
+		display = q.machineConfig.Display
+	}
+
 	opts := []string{
 		"-m", q.machineConfig.Memory,
 		"-smp", fmt.Sprintf("cores=%s", q.machineConfig.CPU),
 		"-rtc", "base=utc,clock=rt",
-		"-nographic",
 		"-device", "virtio-serial", "-nic", fmt.Sprintf("user,hostfwd=tcp::%s-:22", q.machineConfig.SSH.Port),
 	}
+
+	opts = append(opts, strings.Split(display, " ")...)
+
 	if q.machineConfig.CPUType != "" {
 		opts = append(opts, "-cpu", q.machineConfig.CPUType)
 	}

--- a/pkg/machine/types/config.go
+++ b/pkg/machine/types/config.go
@@ -28,6 +28,8 @@ type MachineConfig struct {
 	CPU            string   `yaml:"cpu,omitempty"`
 	Process        string   `yaml:"bin,omitempty"`
 	Args           []string `yaml:"args,omitempty"`
+	// only for qemu
+	Display string `yaml:"display,omitempty"`
 
 	CPUType string `yaml:"cpu,omitempty"`
 
@@ -85,6 +87,15 @@ func WithMemory(mem string) MachineOption {
 	return func(mc *MachineConfig) error {
 		if mem != "" {
 			mc.Memory = mem
+		}
+		return nil
+	}
+}
+
+func WithDisplay(display string) MachineOption {
+	return func(mc *MachineConfig) error {
+		if display != "" {
+			mc.Display = display
 		}
 		return nil
 	}


### PR DESCRIPTION
This is useful when running ginko tests with qemu.

There is some parallel here to the work on virsh, but it's not as comperhansive.
Signed-off-by: Oz Tiram <oz.tiram@gmail.com>