### PR TITLE
Fix inconsistent Machine.Clean()

### DIFF
--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -105,6 +105,7 @@ func (q *QEMU) Stop() error {
 
 func (q *QEMU) Clean() error {
 	if q.machineConfig.StateDir != "" {
+		q.Stop()
 		fmt.Println("Cleaning", q.machineConfig.StateDir)
 		return os.RemoveAll(q.machineConfig.StateDir)
 	}


### PR DESCRIPTION
As described in #5, qemu.Clean() only removed
the state directory, but didn't stop the machine.
Whereas, VBox.Clean() did both.

This adds `Stop` to the qemu.Clean() such that
the behaviour is consistent.

Fix #5 
Signed-off-by: Oz Tiram <oz.tiram@gmail.com>