### PR TITLE
Add DetachCD to machine interface

### DIFF
--- a/matcher/helpers.go
+++ b/matcher/helpers.go
@@ -47,6 +47,10 @@ func (vm VM) Reboot(t ...int) {
 	machineReboot(vm.machine, t...)
 }
 
+func (vm VM) DetachCD() error {
+	return vm.machine.DetachCD()
+}
+
 func (vm VM) HasDir(s string) {
 	machineHasDir(vm.machine, s)
 }
@@ -100,6 +104,10 @@ func HasFile(s string) {
 
 func Reboot(t ...int) {
 	machineReboot(Machine, t...)
+}
+
+func DetachCD() error {
+	return machineDetachCD(Machine)
 }
 
 func HasDir(s string) {
@@ -215,6 +223,10 @@ func machineReboot(m types.Machine, t ...int) {
 		timeout = t[0]
 	}
 	machineEventuallyConnects(m, timeout)
+}
+
+func machineDetachCD(m types.Machine) error {
+	return m.DetachCD()
 }
 
 func machineHasDir(m types.Machine, s string) {

--- a/pkg/machine/docker.go
+++ b/pkg/machine/docker.go
@@ -83,6 +83,10 @@ func (q *Docker) Command(cmd string) (string, error) {
 	return utils.SH(generatedCmd)
 }
 
+func (q *Docker) DetachCD() error {
+	return nil // Does not apply
+}
+
 func (q *Docker) ReceiveFile(src, dst string) error {
 	out, err := utils.SH(fmt.Sprintf("%s cp %s:%s %s", q.whereIsDocker(), q.machineConfig.ID, src, dst))
 	if err != nil {

--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -126,6 +126,11 @@ func (q *QEMU) Command(cmd string) (string, error) {
 	return controller.SSHCommand(q, cmd)
 }
 
+func (q *QEMU) DetachCD() error {
+	fmt.Println("Warning! DetachCD not implemented in QEMU")
+	return nil
+}
+
 func (q *QEMU) ReceiveFile(src, dst string) error {
 	return controller.ReceiveFile(q, src, dst)
 }

--- a/pkg/machine/types/machine.go
+++ b/pkg/machine/types/machine.go
@@ -9,6 +9,7 @@ type Machine interface {
 	Clean() error
 	CreateDisk(diskname, size string) error
 	Command(cmd string) (string, error)
+	DetachCD() error
 	ReceiveFile(src, dst string) error
 	SendFile(src, dst, permissions string) error
 }


### PR DESCRIPTION
although it's only implemented by VBox. That's because we no longer have access to the global Machine object in tests and test that are using VBox used to call DetachCD on the machine directly.

Qemu default boot order is "disk first" so we don't need to eject the cdrom (which fails anyway because there "resource is busy" while booted with the live cd).

Part of: https://github.com/kairos-io/kairos/pull/832