### PR TITLE
Add drivesize option

### DIFF
--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -25,9 +25,10 @@ type QEMU struct {
 func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 	log.Info("Create qemu machine")
 
+	driveSize := q.driveSize()
 	drive := q.machineConfig.Drive
 	if q.machineConfig.AutoDriveSetup && q.machineConfig.Drive == "" {
-		err := q.CreateDisk(fmt.Sprintf("%s.img", q.machineConfig.ID), "40g")
+		err := q.CreateDisk(fmt.Sprintf("%s.img", q.machineConfig.ID), driveSize)
 		if err != nil {
 			return ctx, fmt.Errorf("creating disk with default size: %w", err)
 		}
@@ -192,4 +193,15 @@ func (q *QEMU) SendFile(src, dst, permissions string) error {
 
 func (q *QEMU) monitorSockFile() string {
 	return path.Join(q.machineConfig.StateDir, "qemu-monitor.sock")
+}
+
+// Converts the user's drive size (which is Mb as a string) to the qemu format.
+// https://qemu.readthedocs.io/en/latest/tools/qemu-img.html#cmdoption-qemu-img-arg-create
+func (q *QEMU) driveSize() string {
+	driveSize := types.DefaultDriveSize
+	if q.machineConfig.Drive != "" {
+		driveSize = q.machineConfig.Drive
+	}
+
+	return fmt.Sprintf("%sM", driveSize)
 }

--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -30,7 +30,7 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 	if q.machineConfig.AutoDriveSetup && q.machineConfig.Drive == "" {
 		err := q.CreateDisk(fmt.Sprintf("%s.img", q.machineConfig.ID), driveSize)
 		if err != nil {
-			return ctx, fmt.Errorf("creating disk with default size: %w", err)
+			return ctx, fmt.Errorf("creating disk with size %s: %w", driveSize, err)
 		}
 		drive = filepath.Join(q.machineConfig.StateDir, fmt.Sprintf("%s.img", q.machineConfig.ID))
 	}

--- a/pkg/machine/types/config.go
+++ b/pkg/machine/types/config.go
@@ -8,6 +8,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	DefaultDriveSize = "30000" // Mb
+)
+
 type SSH struct {
 	User string `yaml:"user,omitempty"`
 	Port string `yaml:"port,omitempty"`
@@ -22,6 +26,7 @@ type MachineConfig struct {
 
 	DataSource     string   `yaml:"datasource,omitempty"`
 	Drive          string   `yaml:"drive,omitempty"`
+	DriveSize      string   `yaml:"drivesize,omitempty"`
 	AutoDriveSetup bool     `yaml:"auto_drive,omitempty"`
 	ID             string   `yaml:"id,omitempty"`
 	Memory         string   `yaml:"memory,omitempty"`
@@ -162,6 +167,16 @@ func WithDrive(drive string) MachineOption {
 	return func(mc *MachineConfig) error {
 		if drive != "" {
 			mc.Drive = drive
+		}
+
+		return nil
+	}
+}
+
+func WithDriveSize(drivesize string) MachineOption {
+	return func(mc *MachineConfig) error {
+		if drivesize != "" {
+			mc.DriveSize = drivesize
 		}
 
 		return nil

--- a/pkg/machine/vbox.go
+++ b/pkg/machine/vbox.go
@@ -67,9 +67,13 @@ func (v *VBox) Create(ctx context.Context) (context.Context, error) {
 		return ctx, fmt.Errorf("while set VM: %w - %s", err, out)
 	}
 
+	driveSize := types.DefaultDriveSize
+	if v.machineConfig.Drive != "" {
+		driveSize = v.machineConfig.Drive
+	}
 	drive := v.machineConfig.Drive
 	if v.machineConfig.AutoDriveSetup && v.machineConfig.Drive == "" {
-		err := v.CreateDisk(fmt.Sprintf("%s.vdi", v.machineConfig.ID), "30000")
+		err := v.CreateDisk(fmt.Sprintf("%s.vdi", v.machineConfig.ID), driveSize)
 		if err != nil {
 			return ctx, err
 		}


### PR DESCRIPTION
Allows the user to specify the disk size for the VM. The default `40g` of qemu was too much for Github Action workers.

Needed here: https://github.com/kairos-io/provider-kairos/pull/306#