### PR TITLE
Get rid of unecessary go routines

### DIFF
--- a/matcher/helpers.go
+++ b/matcher/helpers.go
@@ -220,20 +220,17 @@ func machineSudo(m types.Machine, c string) (string, error) {
 
 		stdInPipe.Close()
 	}()
-	go func() {
-		_, err := io.Copy(&outBuf, stdOutPipe)
-		if err != nil {
-			panic(err)
-		}
-	}()
-	go func() {
-		_, err := io.Copy(&outBuf, stdErrPipe)
-		if err != nil {
-			panic(err)
-		}
-	}()
 
 	err = session.Run(`sudo /bin/sh`)
+
+	_, copyErr := io.Copy(&outBuf, stdOutPipe)
+	if copyErr != nil {
+		panic(err)
+	}
+	_, copyErr = io.Copy(&outBuf, stdErrPipe)
+	if copyErr != nil {
+		panic(err)
+	}
 
 	return outBuf.String(), err
 }


### PR DESCRIPTION
We only write the input (command) using a go routine. As soon as the `Run` has returned, we can simply collect the other 2 buffers sequentially.

Sometimes the go routines didn't have enough  time to write the data to the buffer and the result was an empty string (although there was output from the command).