### PR TITLE
Close ssh session when done

### DIFF
--- a/matcher/helpers.go
+++ b/matcher/helpers.go
@@ -197,6 +197,7 @@ func machineSudo(m types.Machine, c string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer session.Close()
 
 	stdOutPipe, err := session.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Maybe this is what causes the kairos-io/kairos CI to break randomly with authentication errors when trying to ssh to the VM. E.g. here: https://github.com/kairos-io/kairos/actions/runs/5962679820/job/16174323394 