### PR TITLE
optional disable of default network settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/spectrocloud/peg
 go 1.18
 
 require (
-	github.com/bramvdbogaerde/go-scp v1.2.0
+	github.com/bramvdbogaerde/go-scp v1.5.0
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/codingsince1985/checksum v1.2.4
 	github.com/ipfs/go-log v1.0.5

--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -83,7 +83,12 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 		"-smp", fmt.Sprintf("cores=%s", q.machineConfig.CPU),
 		"-rtc", "base=utc,clock=rt",
 		"-monitor", fmt.Sprintf("unix:%s,server,nowait", q.monitorSockFile()),
-		"-device", "virtio-serial", "-nic", fmt.Sprintf("user,hostfwd=tcp::%s-:22", q.machineConfig.SSH.Port),
+		"-device", "virtio-serial",
+	}
+
+	// Add default networking unless disabled
+	if !q.machineConfig.DisableDefaultNetworking {
+		opts = append(opts, "-nic", fmt.Sprintf("user,hostfwd=tcp::%s-:22", q.machineConfig.SSH.Port))
 	}
 
 	opts = append(opts, strings.Split(display, " ")...)

--- a/pkg/machine/types/config.go
+++ b/pkg/machine/types/config.go
@@ -38,6 +38,9 @@ type MachineConfig struct {
 
 	CPUType string `yaml:"cpu,omitempty"`
 
+	// Network configuration
+	DisableDefaultNetworking bool `yaml:"disable_default_networking,omitempty"`
+
 	SSH    *SSH   `yaml:"ssh,omitempty"`
 	Engine Engine `yaml:"engine,omitempty"`
 
@@ -262,5 +265,18 @@ var EnableAutoDriveSetup MachineOption = func(mc *MachineConfig) error {
 // DisableAutoDriveSetup disables automatic disk setup.
 var DisableAutoDriveSetup MachineOption = func(mc *MachineConfig) error {
 	mc.AutoDriveSetup = false
+	return nil
+}
+
+// DisableDefaultNetworking disables the default -nic networking setup.
+// This allows for custom network configuration without conflicts.
+var DisableDefaultNetworking MachineOption = func(mc *MachineConfig) error {
+	mc.DisableDefaultNetworking = true
+	return nil
+}
+
+// EnableDefaultNetworking enables the default -nic networking setup (default behavior).
+var EnableDefaultNetworking MachineOption = func(mc *MachineConfig) error {
+	mc.DisableDefaultNetworking = false
 	return nil
 }


### PR DESCRIPTION
For use cases where the default qemu nat cannot be used, support disabling it so custom networking can be added.  Default NAT expects DHCP to serve the IP address and creates forward rules to the DHCP IP. 

Additionally support qemu-system-x86_64 installed in different paths.  