### PR TITLE
feat: Add architecture support for QEMU configuration

### DIFF
--- a/matcher/helpers.go
+++ b/matcher/helpers.go
@@ -258,10 +258,18 @@ func machineEventuallyConnects(m types.Machine, t ...int) {
 	if len(t) > 0 {
 		dur = t[0]
 	}
+	var lastPrint time.Time
 	Eventually(func() string {
+		// Every 30 seconds print a message to show progress
+		now := time.Now()
+		if lastPrint.IsZero() || now.Sub(lastPrint) >= 30*time.Second {
+			fmt.Println("Still trying to connect...")
+			lastPrint = now
+		}
+
 		out, _ := m.Command("echo ping")
 		return out
-	}, time.Duration(time.Duration(dur)*time.Second), time.Duration(5*time.Second)).Should(Equal("ping\n"))
+	}, time.Duration(dur)*time.Second, 5*time.Second).Should(Equal("ping\n"), "Machine did not become reachable in time")
 }
 
 func machineReboot(m types.Machine, t ...int) {

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +31,7 @@ func prepare(mc *types.MachineConfig) error {
 	}
 
 	if mc.StateDir == "" {
-		f, err := ioutil.TempDir("", "peg")
+		f, err := os.MkdirTemp("", "peg")
 		if err != nil {
 			return err
 		}

--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -24,27 +24,28 @@ type QEMU struct {
 }
 
 // findQEMUBinary searches for qemu-system-x86_64 in common installation paths
-func findQEMUBinary() (string, error) {
+func findQEMUBinary(arch string) (string, error) {
+	qemuBinary := fmt.Sprintf("qemu-system-%s", arch)
 	// Common paths where QEMU might be installed
 	commonPaths := []string{
-		"/home/linuxbrew/.linuxbrew/bin/qemu-system-x86_64", // Homebrew on Linux
-		"/usr/local/bin/qemu-system-x86_64",                 // Manual install
-		"/usr/bin/qemu-system-x86_64",                       // System package
-		"/opt/homebrew/bin/qemu-system-x86_64",              // Homebrew on macOS ARM
-		"/usr/local/homebrew/bin/qemu-system-x86_64",        // Homebrew on macOS Intel
+		"/home/linuxbrew/.linuxbrew/bin/", // Homebrew on Linux
+		"/usr/local/bin/",                 // Manual install
+		"/usr/bin/",                       // System package
+		"/opt/homebrew/bin/",              // Homebrew on macOS ARM
+		"/usr/local/homebrew/bin/",        // Homebrew on macOS Intel
 	}
 
 	// Check each common path first
 	for _, path := range commonPaths {
-		if _, err := os.Stat(path); err == nil {
-			return path, nil
+		if _, err := os.Stat(filepath.Join(path, qemuBinary)); err == nil {
+			return filepath.Join(path, qemuBinary), nil
 		}
 	}
 
 	// Fallback to searching in PATH
-	path, err := exec.LookPath("qemu-system-x86_64")
+	path, err := exec.LookPath(qemuBinary)
 	if err != nil {
-		return "", fmt.Errorf("qemu-system-x86_64 not found in common paths or PATH: %w", err)
+		return "", fmt.Errorf("%s not found in common paths or PATH: %w", qemuBinary, err)
 	}
 
 	return path, nil
@@ -67,17 +68,54 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 	}
 
 	genDrives := func(m types.MachineConfig) []string {
-		allDrives := []string{}
-		if m.ISO != "" {
-			allDrives = append(allDrives, "-drive", fmt.Sprintf("if=ide,media=cdrom,file=%s", m.ISO))
+		var allDrives []string
+		scsiAdded := false
+		id := 0
+
+		// User disks: bootindex 1..N (highest priority)
+		for i, d := range userDrives {
+			driveID := fmt.Sprintf("drv%d", id)
+			id++
+
+			allDrives = append(allDrives,
+				"-drive", fmt.Sprintf("if=none,id=%s,file=%s", driveID, d),
+				"-device", fmt.Sprintf("virtio-blk-pci,drive=%s,bootindex=%d", driveID, i+1),
+			)
 		}
-		if m.DataSource != "" {
-			allDrives = append(allDrives, "-drive", fmt.Sprintf("if=ide,media=cdrom,file=%s", m.DataSource))
-		}
-		if len(userDrives) != 0 {
-			for _, d := range userDrives {
-				allDrives = append(allDrives, "-drive", fmt.Sprintf("if=virtio,media=disk,file=%s", d))
+
+		// If we have any CDROMs we want them as /dev/srX => add a virtio-scsi controller once
+		addSCSIIfNeeded := func() {
+			if !scsiAdded {
+				// create a virtio SCSI controller
+				allDrives = append(allDrives,
+					"-device", "virtio-scsi-pci,id=scsi0",
+				)
+				scsiAdded = true
 			}
+		}
+
+		// Primary ISO -> appear as /dev/srX (scsi-cd)
+		if m.ISO != "" {
+			addSCSIIfNeeded()
+			driveID := fmt.Sprintf("drv%d", id)
+			id++
+
+			allDrives = append(allDrives,
+				"-drive", fmt.Sprintf("if=none,id=%s,media=cdrom,file=%s", driveID, m.ISO),
+				"-device", fmt.Sprintf("scsi-cd,drive=%s,bus=scsi0.0,bootindex=50", driveID),
+			)
+		}
+
+		// Data-source ISO -> also /dev/srX
+		if m.DataSource != "" {
+			addSCSIIfNeeded()
+			driveID := fmt.Sprintf("drv%d", id)
+			id++
+
+			allDrives = append(allDrives,
+				"-drive", fmt.Sprintf("if=none,id=%s,media=cdrom,file=%s", driveID, m.DataSource),
+				"-device", fmt.Sprintf("scsi-cd,drive=%s,bus=scsi0.0,bootindex=60", driveID),
+			)
 		}
 
 		return allDrives
@@ -88,7 +126,7 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 		processName = q.machineConfig.Process
 	} else {
 		var err error
-		processName, err = findQEMUBinary()
+		processName, err = findQEMUBinary(q.machineConfig.Arch)
 		if err != nil {
 			return ctx, fmt.Errorf("failed to find QEMU binary: %w", err)
 		}
@@ -131,7 +169,23 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 		opts = append(opts, "-cpu", q.machineConfig.CPUType)
 	}
 
+	if q.machineConfig.Arch == "aarch64" && q.machineConfig.CPUType == "" {
+		// For aarch64, set a default CPU type if not specified
+		opts = append(opts, "-cpu", "max")
+	}
+
 	opts = append(opts, q.machineConfig.Args...)
+
+	if q.machineConfig.Arch == "aarch64" {
+		// For aarch64, we need to specify machine type and firmware
+		opts = append(opts,
+			"-machine", "virt,accel=tcg,acpi=on,gic-version=2",
+		)
+	}
+
+	opts = append(opts, "-boot", "order=dc,menu=on")
+
+	log.Infof("Creating QEMU machine with args: %s", strings.Join(append(opts, genDrives(q.machineConfig)...), " "))
 
 	qemu := process.New(
 		process.WithName(processName),
@@ -143,7 +197,6 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 	q.process = qemu
 
 	newCtx := monitor(ctx, qemu, q.machineConfig.OnFailure)
-
 	return newCtx, qemu.Run()
 }
 

--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -167,9 +167,7 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 
 	if q.machineConfig.CPUType != "" {
 		opts = append(opts, "-cpu", q.machineConfig.CPUType)
-	}
-
-	if q.machineConfig.Arch == "aarch64" && q.machineConfig.CPUType == "" {
+	} else if q.machineConfig.Arch == "aarch64" {
 		// For aarch64, set a default CPU type if not specified
 		opts = append(opts, "-cpu", "max")
 	}

--- a/pkg/machine/qemu.go
+++ b/pkg/machine/qemu.go
@@ -181,6 +181,11 @@ func (q *QEMU) Create(ctx context.Context) (context.Context, error) {
 		)
 	}
 
+	// Use QEMU boot order "dc" (disk, then cdrom). This works in conjunction with
+	// per-drive bootindex values: 1-N for disks, 50 for ISO, and 60 for the
+	// cloud-init/DataSource drive. The boot order ensures disks are considered
+	// first, while bootindex controls the precedence among multiple devices of
+	// the same type.
 	opts = append(opts, "-boot", "order=dc,menu=on")
 
 	log.Infof("Creating QEMU machine with args: %s", strings.Join(append(opts, genDrives(q.machineConfig)...), " "))

--- a/pkg/machine/types/config.go
+++ b/pkg/machine/types/config.go
@@ -43,6 +43,7 @@ type MachineConfig struct {
 
 	SSH    *SSH   `yaml:"ssh,omitempty"`
 	Engine Engine `yaml:"engine,omitempty"`
+	Arch   string `yaml:"arch,omitempty"`
 
 	OnFailure func(*process.Process)
 }
@@ -63,6 +64,7 @@ func DefaultMachineConfig() *MachineConfig {
 		SSH:            &SSH{},
 		CPU:            "2",
 		Memory:         "2048",
+		Arch:           "x86_64",
 	}
 }
 
@@ -239,6 +241,15 @@ func WithStateDir(dir string) MachineOption {
 	return func(mc *MachineConfig) error {
 		if dir != "" {
 			mc.StateDir = dir
+		}
+		return nil
+	}
+}
+
+func WithArch(arch string) MachineOption {
+	return func(mc *MachineConfig) error {
+		if arch != "" {
+			mc.Arch = arch
 		}
 		return nil
 	}


### PR DESCRIPTION
- Introduced `Arch` field in `MachineConfig` to specify architecture
- Updated `findQEMUBinary` to accept architecture as a parameter
- Enhanced drive configuration to support different architectures
- Default architecture set to `x86_64` for compatibility
- Improved connection progress logging during machine setup

This introduces support for aarch64 testing by setting all the bits and bops needed to run qemu-system-aarch64 Also improves the disk stuff to have a proper booindex by default, which means it will try to boot from HDD, then from CDROM and finally from the metadata cdrom if there is any.

Also introduces some stdout printing when we are trying to connect to let the user know that we are still trying, otherwise its an empty output for a long time. It will log a message every 30 seconds.

Ideally in the future the bootindex or boot order could be potentially be set by the consumer of the vm with a different field, but for now this keeps the same behaviour as before.